### PR TITLE
Removed the max_step option in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Output files will be saved in the `output directory`. Default option is same wit
 ```
 python run.py \
     -id example/diels \
-    -sd example/diels
+    -od example/diels
 ```
 
 ## Output

--- a/examples/diels/option
+++ b/examples/diels/option
@@ -1,4 +1,3 @@
-max_step=3
 step_size=0.1 
 unit=Hartree
 calculator=Gaussian


### PR DESCRIPTION
In the previous option file in example , there were redundant options and the program reported an error：

```
Wrong attribute(s) (=max_step) is given! Check the option file !!!
Possible attributes are 'working_directory', 'num_relaxation','step_size','unit','calculator','command','use_hessian','hessian_update','reoptimize'
```

Removed the max_step option in the example.